### PR TITLE
Add .stack-work to .gitignore, up to LTS-12.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-11.14
+resolver: lts-12.14
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This fixes #6. I also noticed that the ``.gitignore`` was missing ``.stack-work``, which is probably not a good idea, so I fixed that too.